### PR TITLE
Resolve PR number for Codecov workflow_run

### DIFF
--- a/.github/workflows/Codecov.yml
+++ b/.github/workflows/Codecov.yml
@@ -11,6 +11,10 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event != 'schedule'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -26,10 +30,22 @@ jobs:
       - name: Restore coverage files
         run: |
           cp -v /tmp/coverage-artifacts/*.json . 2>/dev/null || true
+      - name: Resolve PR number on PR events
+        id: resolve_pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER=""
+          if [ "${{ github.event.workflow_run.event }}" = "pull_request" ]; then
+            HEAD="${{ github.event.workflow_run.head_repository.owner.login }}:${{ github.event.workflow_run.head_branch }}"
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/pulls?state=all&head=${HEAD}" --jq ".[0].number // empty")
+          fi
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "Resolved PR: ${PR_NUMBER:-(none)}"
       - name: Upload to Codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           CODECOV_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           CODECOV_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          CODECOV_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          CODECOV_PR: ${{ steps.resolve_pr.outputs.pr_number }}
         run: ./dev/upload_codecov.sh

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -39,7 +39,6 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v4
         with:
-          # the persisted token interferes with the subsplit token used below
           persist-credentials: false
           fetch-depth: 0
       - name: Move checked out repo to GAP user root dir

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -10,7 +10,7 @@ SetPackageInfo( rec(
 
 PackageName := "FinGSetsForCAP",
 Subtitle := "The (skeletal) elementary topos of finite G-sets",
-Version := "2026.04-06",
+Version := "2026.04-07",
 
 Date := (function ( ) if IsBound( GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE ) then return GAPInfo.SystemEnvironment.GAP_PKG_RELEASE_DATE; else return Concatenation( ~.Version{[ 1 .. 4 ]}, "-", ~.Version{[ 6, 7 ]}, "-01" ); fi; end)( ),
 License := "GPL-2.0-or-later",


### PR DESCRIPTION
- Resolve PR number via gh for workflow_run on pull_request and expose as output.
- Use resolved PR for CODECOV_PR; keep behavior for non-PR runs.
- Remove redundant comment in Tests workflow.

Bump version of FinGSetsForCAP to v2026.04-07